### PR TITLE
Harden parsing API and add security/fuzz/benchmark infrastructure

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,17 @@
+name: PR Benchmarks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  bench:
+    uses: terjekv/github-action-iai-callgrind/.github/workflows/rust-pr-bench.yml@v2
+    with:
+      backend: iai-callgrind
+      auto_discover: true
+      regression_threshold_pct_iai_callgrind: 3
+      fail_on_regression: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Lint
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Test
+        run: cargo test --all-features
+
+      - name: Doc tests
+        run: cargo test --doc --all-features
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-deny
+        run: cargo install cargo-deny --locked
+
+      - name: Dependency policy check
+        run: cargo deny check advisories bans sources
+
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+
+      - name: Advisory scan
+        run: cargo audit

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/fuzz/artifacts
+/fuzz/corpus

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,13 @@
+{
+    "default": true,
+    "MD013": {
+        "line_length": 120,
+        "code_blocks": false,
+        "tables": false
+    },
+    "MD033": false,
+    "MD041": false,
+    "no-duplicate-heading": {
+        "siblings_only": true
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog, and this project follows Semantic Versioning.
+
+## [Unreleased]
+
+### Added
+
+- Introduced parse hardening via ParseOptions with strict JSON mode and configurable path depth and array index limits.
+- Added dedicated error variants for strict JSON failures and limit validation failures.
+- Added CI workflows for formatting, linting, tests, doc tests, dependency policy checks, and advisory scans.
+- Added fuzzing harness and targets for parser/apply paths and deep path/index stress scenarios.
+- Added benchmark infrastructure with iai-callgrind and scenario-specific fan-out benchmark targets.
+- Added PR benchmark workflow integration using terjekv/github-action-iai-callgrind.
+- Added CONTRIBUTING guide and local quality/security helper script.
+
+### Changed
+
+- Migrated parameterized tests from yare to rstest.
+- Encapsulated Jqesque internals with constructor/getter APIs and limit validation on apply paths.
+- Reduced clone churn in insert path manipulation by passing values by reference in recursion.
+- Updated documentation and examples to prefer options-based parsing for untrusted input.
+
+### Security
+
+- Strengthened protections against resource-exhaustion style inputs by enforcing parse/apply safety limits.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,89 @@
+# Contributing
+
+Thanks for contributing to jqesque.
+
+## Local quality checks
+
+Run these before opening a PR:
+
+```bash
+./scripts/check.sh
+```
+
+Equivalent manual commands:
+
+```bash
+cargo fmt --all
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+cargo test --doc --all-features
+```
+
+## Security checks
+
+Install and run dependency/security checks:
+
+```bash
+cargo install cargo-deny --locked
+cargo deny check advisories bans sources
+
+cargo install cargo-audit --locked
+cargo audit
+```
+
+## Fuzzing
+
+Install cargo-fuzz once:
+
+```bash
+cargo install cargo-fuzz
+```
+
+Run the existing fuzz targets:
+
+```bash
+cargo fuzz run parse_apply
+cargo fuzz run deep_paths_indices
+```
+
+To keep runs bounded locally, use:
+
+```bash
+cargo fuzz run deep_paths_indices -- -max_total_time=60
+```
+
+## Benchmarks
+
+This repository uses `iai-callgrind` benchmark targets in `benches/`.
+
+Install the runner:
+
+```bash
+cargo install cargo-iai-callgrind
+```
+
+Run selected callgrind benchmarks:
+
+```bash
+cargo iai-callgrind --bench parse_scalar_small_callgrind
+cargo iai-callgrind --bench parse_object_large_callgrind
+cargo iai-callgrind --bench insert_array_sparse_medium_callgrind
+cargo iai-callgrind --bench merge_deep_object_large_callgrind
+```
+
+Available benchmark targets are intentionally split by scenario and size to maximize fan-out:
+
+- `parse_scalar_small_callgrind`
+- `parse_array_medium_callgrind`
+- `parse_deep_path_medium_callgrind`
+- `parse_object_large_callgrind`
+- `insert_object_small_callgrind`
+- `insert_array_sparse_medium_callgrind`
+- `insert_deep_path_medium_callgrind`
+- `insert_array_dense_large_callgrind`
+- `merge_object_small_callgrind`
+- `merge_array_medium_callgrind`
+- `merge_deep_object_large_callgrind`
+
+CI runs PR benchmarks through the reusable workflow in
+`terjekv/github-action-iai-callgrind`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,157 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "iai-callgrind"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9e864ad001cbbf35a64f7b574998823b8622bb483a25246fa1b0e2b3888686"
+dependencies = [
+ "bincode",
+ "derive_more",
+ "iai-callgrind-macros",
+ "iai-callgrind-runner",
+]
+
+[[package]]
+name = "iai-callgrind-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9cee6c3bc32b63ff40e5e56190b1276d2bd0e0b319aa6f998864c27865d3b4e"
+dependencies = [
+ "derive_more",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "iai-callgrind-runner"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a82491521e6505b06a824274712a1307904e7cdfdf047735f7dfdb28b5f7a337"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,14 +163,15 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 name = "jqesque"
 version = "0.0.3"
 dependencies = [
+ "iai-callgrind",
  "json-patch",
  "jsonptr",
  "nom",
  "nom-language",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "yare",
 ]
 
 [[package]]
@@ -69,6 +221,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,25 +276,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -123,6 +402,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -176,27 +461,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.9+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
-name = "yare"
-version = "3.0.0"
+name = "winnow"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd38b61ea41431e67d75175dedcf452d555e99a08a5d0cf9ea6fdd35ef615c7c"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
- "yare-macro",
-]
-
-[[package]]
-name = "yare-macro"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8d4626f0bd81499df0d68262eb1b819b0025edc6832ade7fbf10597b008efe"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jqesque"
@@ -171,14 +171,14 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "json-patch"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "159294d661a039f7644cea7e4d844e6b25aaf71c1ffe9d73a96d768c24b0faf4"
+checksum = "f300e415e2134745ef75f04562dd0145405c2f7fd92065db029ac4b16b57fe90"
 dependencies = [
  "jsonptr",
  "serde",
@@ -198,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nom"
@@ -259,18 +259,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -312,21 +312,20 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
  "rstest_macros",
- "rustc_version",
 ]
 
 [[package]]
 name = "rstest_macros"
-version = "0.24.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
 dependencies = [
  "cfg-if",
  "glob",
@@ -348,12 +347,6 @@ checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semver"
@@ -393,14 +386,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -411,9 +405,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -431,11 +425,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -451,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -492,9 +486,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "winnow"
@@ -504,3 +498,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "iai-callgrind"
-version = "0.14.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9e864ad001cbbf35a64f7b574998823b8622bb483a25246fa1b0e2b3888686"
+checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
 dependencies = [
  "bincode",
  "derive_more",
@@ -121,9 +121,9 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-macros"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cee6c3bc32b63ff40e5e56190b1276d2bd0e0b319aa6f998864c27865d3b4e"
+checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
 dependencies = [
  "derive_more",
  "proc-macro-error2",
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-runner"
-version = "0.14.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82491521e6505b06a824274712a1307904e7cdfdf047735f7dfdb28b5f7a337"
+checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ json-patch = "4"
 jsonptr = "0"
 
 [dev-dependencies]
-rstest = "0.24"
+rstest = "0.26"
 iai-callgrind = "0.16.1"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,51 @@ nom = { version = "8", features = ["alloc"] }
 thiserror = "2"
 json-patch = "4"
 jsonptr = "0"
-yare = "3"
+
+[dev-dependencies]
+rstest = "0.24"
+iai-callgrind = "0.14"
+
+[[bench]]
+name = "parse_scalar_small_callgrind"
+harness = false
+
+[[bench]]
+name = "parse_array_medium_callgrind"
+harness = false
+
+[[bench]]
+name = "parse_deep_path_medium_callgrind"
+harness = false
+
+[[bench]]
+name = "parse_object_large_callgrind"
+harness = false
+
+[[bench]]
+name = "insert_object_small_callgrind"
+harness = false
+
+[[bench]]
+name = "insert_array_sparse_medium_callgrind"
+harness = false
+
+[[bench]]
+name = "insert_deep_path_medium_callgrind"
+harness = false
+
+[[bench]]
+name = "insert_array_dense_large_callgrind"
+harness = false
+
+[[bench]]
+name = "merge_object_small_callgrind"
+harness = false
+
+[[bench]]
+name = "merge_array_medium_callgrind"
+harness = false
+
+[[bench]]
+name = "merge_deep_object_large_callgrind"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ jsonptr = "0"
 
 [dev-dependencies]
 rstest = "0.24"
-iai-callgrind = "0.14"
+iai-callgrind = "0.16.1"
 
 [[bench]]
 name = "parse_scalar_small_callgrind"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,40 @@ Paths can be nested and can include array indices. The path can be separated by 
 
 Values are parsed by serde_json. The library will attempt to parse the value as a JSON value, defaulting to string.
 
+## Safety and ParseOptions
+
+When parsing untrusted input (e.g. from HTTP requests, CLI arguments, or config files), use
+`ParseOptions` to bound resource usage and enforce strict value parsing.
+
+- `strict_json_values(true)`: require the right-hand side to be valid JSON.
+- `max_path_depth(n)`: reject deeply nested paths.
+- `max_array_index(n)`: reject oversized array indices.
+
+The default limits are exported as `DEFAULT_MAX_PATH_DEPTH` and `DEFAULT_MAX_ARRAY_INDEX`.
+
+### API selection guide
+
+| API | Best for | Notes |
+| --- | --- | --- |
+| `input.parse::<Jqesque>()` | Quick defaults with dot separator | Uses permissive value parsing and default limits. |
+| `Jqesque::from_str_with_separator(input, separator)` | Convenience with custom separator | Prefer for trusted/simple input. |
+| `Jqesque::from_str_with_options(input, options)` | Untrusted input and production boundaries | Recommended: supports strict parsing and custom limits. |
+
+### Recommended setup for untrusted input
+
+```rust
+use jqesque::{Jqesque, ParseOptions, Separator};
+
+let options = ParseOptions::new(Separator::Dot)
+    .strict_json_values(true)
+    .max_path_depth(64)
+    .max_array_index(10_000);
+
+let jqesque = Jqesque::from_str_with_options("settings.theme=\"dark\"", options)?;
+```
+
+If you prefer permissive parsing (legacy behavior), keep `strict_json_values(false)`.
+
 ## Examples
 
 ### Basic Usage
@@ -60,8 +94,12 @@ fn main() {
     // Without using turbofish syntax:
     // let jqesque: Jqesque = input.parse().unwrap();
 
-    // Alternatively, if you want to specify the separator:
-    // let jqesque = Jqesque::from_str_with_separator(input, Separator::Dot).unwrap();
+    // Recommended for untrusted input:
+    // let options = ParseOptions::new(Separator::Dot)
+    //     .strict_json_values(true)
+    //     .max_path_depth(64)
+    //     .max_array_index(10_000);
+    // let jqesque = Jqesque::from_str_with_options(input, options).unwrap();
 
     let json_output = jqesque.as_json();
     assert_eq!(json_output, json!({
@@ -79,12 +117,16 @@ fn main() {
 ### Specifying the separator
 
 ```rust
-use jqesque::{Jqesque, Separator};
+use jqesque::{Jqesque, ParseOptions, Separator};
 use serde_json::json;
 
 fn main() {
     let input = ">foo/bar[0]/baz=true";
-    let jqesque = Jqesque::from_str_with_separator(input, Separator::Slash).unwrap();
+    let options = ParseOptions::new(Separator::Slash)
+        .strict_json_values(true)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+    let jqesque = Jqesque::from_str_with_options(input, options).unwrap();
 
     let json_output = jqesque.as_json();
     assert_eq!(json_output, json!({
@@ -103,7 +145,7 @@ fn main() {
 
 ```rust
 use serde_json::json;
-use jqesque::{Jqesque, Separator};
+use jqesque::{Jqesque, ParseOptions, Separator};
 
 let mut json_obj = json!({
     "settings": {
@@ -116,7 +158,11 @@ let mut json_obj = json!({
 });
 
 let input = ">settings.theme={\"color\":\"blue\",\"font\":\"Helvetica\"}";
-let jqesque = Jqesque::from_str_with_separator(input, Separator::Dot).unwrap();
+let options = ParseOptions::new(Separator::Dot)
+    .strict_json_values(true)
+    .max_path_depth(64)
+    .max_array_index(10_000);
+let jqesque = Jqesque::from_str_with_options(input, options).unwrap();
 
 jqesque.apply_to(&mut json_obj);
 
@@ -137,7 +183,7 @@ assert_eq!(json_obj, expected);
 
 ```rust
 use serde_json::json;
-use jqesque::{Jqesque, Separator};
+use jqesque::{Jqesque, ParseOptions, Separator};
 
 let mut json_obj = json!({
     "settings": {
@@ -150,7 +196,11 @@ let mut json_obj = json!({
 });
 
 let input = "~settings.theme={\"color\":\"blue\",\"font\":\"Helvetica\"}";
-let jqesque = Jqesque::from_str_with_separator(input, Separator::Dot).unwrap();
+let options = ParseOptions::new(Separator::Dot)
+    .strict_json_values(true)
+    .max_path_depth(64)
+    .max_array_index(10_000);
+let jqesque = Jqesque::from_str_with_options(input, options).unwrap();
 
 jqesque.apply_to(&mut json_obj);
 
@@ -167,6 +217,41 @@ let expected = json!({
 assert_eq!(json_obj, expected);
 // Note that the "size" key in the original "theme" object is preserved.
 ```
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local quality checks, dependency/security checks,
+and fuzzing commands.
+
+## Benchmarking
+
+Benchmarks are split into small, file-scoped targets in `benches/` to improve fan-out and
+parallel CI execution.
+
+- `benches/parse_scalar_small_callgrind.rs`
+- `benches/parse_array_medium_callgrind.rs`
+- `benches/parse_deep_path_medium_callgrind.rs`
+- `benches/parse_object_large_callgrind.rs`
+- `benches/insert_object_small_callgrind.rs`
+- `benches/insert_array_sparse_medium_callgrind.rs`
+- `benches/insert_deep_path_medium_callgrind.rs`
+- `benches/insert_array_dense_large_callgrind.rs`
+- `benches/merge_object_small_callgrind.rs`
+- `benches/merge_array_medium_callgrind.rs`
+- `benches/merge_deep_object_large_callgrind.rs`
+
+Install the runner and run selected benchmark targets:
+
+```bash
+cargo install cargo-iai-callgrind
+cargo iai-callgrind --bench parse_scalar_small_callgrind
+cargo iai-callgrind --bench parse_object_large_callgrind
+cargo iai-callgrind --bench insert_array_sparse_medium_callgrind
+cargo iai-callgrind --bench merge_deep_object_large_callgrind
+```
+
+PR benchmark reporting and regression gating uses
+`terjekv/github-action-iai-callgrind` via `.github/workflows/bench.yml`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,10 @@ cargo iai-callgrind --bench merge_deep_object_large_callgrind
 PR benchmark reporting and regression gating uses
 `terjekv/github-action-iai-callgrind` via `.github/workflows/bench.yml`.
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release notes and notable changes.
+
 ## License
 
 See the [LICENSE](LICENSE) file for details.

--- a/benches/insert_array_dense_large_callgrind.rs
+++ b/benches/insert_array_dense_large_callgrind.rs
@@ -1,0 +1,27 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+use serde_json::{json, Value};
+
+#[library_benchmark]
+fn insert_array_dense_large() -> Value {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let parsed = Jqesque::from_str_with_options(
+        ">items=[{\"id\":1},{\"id\":2},{\"id\":3},{\"id\":4},{\"id\":5},{\"id\":6},{\"id\":7},{\"id\":8}]",
+        options,
+    )
+    .expect("parse ok");
+
+    let mut json_obj = json!({"items": []});
+    parsed.apply_to(&mut json_obj).expect("apply ok");
+    json_obj
+}
+
+library_benchmark_group!(
+    name = insert_array_dense_large_group;
+    benchmarks = insert_array_dense_large
+);
+main!(library_benchmark_groups = insert_array_dense_large_group);

--- a/benches/insert_array_sparse_medium_callgrind.rs
+++ b/benches/insert_array_sparse_medium_callgrind.rs
@@ -1,0 +1,24 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+use serde_json::{json, Value};
+
+#[library_benchmark]
+fn insert_array_sparse_medium() -> Value {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let parsed =
+        Jqesque::from_str_with_options(">items[512].name=item", options).expect("parse ok");
+
+    let mut json_obj = json!({"items": []});
+    parsed.apply_to(&mut json_obj).expect("apply ok");
+    json_obj
+}
+
+library_benchmark_group!(
+    name = insert_array_sparse_medium_group;
+    benchmarks = insert_array_sparse_medium
+);
+main!(library_benchmark_groups = insert_array_sparse_medium_group);

--- a/benches/insert_deep_path_medium_callgrind.rs
+++ b/benches/insert_deep_path_medium_callgrind.rs
@@ -1,0 +1,24 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+use serde_json::{json, Value};
+
+#[library_benchmark]
+fn insert_deep_path_medium() -> Value {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let parsed =
+        Jqesque::from_str_with_options(">a.b.c.d.e.f.g.h.i.j.k=42", options).expect("parse ok");
+
+    let mut json_obj = json!({"a": {"b": {"c": {}}}});
+    parsed.apply_to(&mut json_obj).expect("apply ok");
+    json_obj
+}
+
+library_benchmark_group!(
+    name = insert_deep_path_medium_group;
+    benchmarks = insert_deep_path_medium
+);
+main!(library_benchmark_groups = insert_deep_path_medium_group);

--- a/benches/insert_object_small_callgrind.rs
+++ b/benches/insert_object_small_callgrind.rs
@@ -1,0 +1,21 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+use serde_json::{json, Value};
+
+#[library_benchmark]
+fn insert_object_small() -> Value {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let parsed =
+        Jqesque::from_str_with_options(">settings.theme.color=blue", options).expect("parse ok");
+
+    let mut json_obj = json!({"settings": {"theme": {"font": "mono"}}});
+    parsed.apply_to(&mut json_obj).expect("apply ok");
+    json_obj
+}
+
+library_benchmark_group!(name = insert_object_small_group; benchmarks = insert_object_small);
+main!(library_benchmark_groups = insert_object_small_group);

--- a/benches/merge_array_medium_callgrind.rs
+++ b/benches/merge_array_medium_callgrind.rs
@@ -1,0 +1,21 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+use serde_json::{json, Value};
+
+#[library_benchmark]
+fn merge_array_medium() -> Value {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let parsed = Jqesque::from_str_with_options("~items=[10,11,12,13,14,15,16,17]", options)
+        .expect("parse ok");
+
+    let mut json_obj = json!({"items": [1,2,3,4,5,6,7,8]});
+    parsed.apply_to(&mut json_obj).expect("apply ok");
+    json_obj
+}
+
+library_benchmark_group!(name = merge_array_medium_group; benchmarks = merge_array_medium);
+main!(library_benchmark_groups = merge_array_medium_group);

--- a/benches/merge_deep_object_large_callgrind.rs
+++ b/benches/merge_deep_object_large_callgrind.rs
@@ -1,0 +1,39 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+use serde_json::{json, Value};
+
+#[library_benchmark]
+fn merge_deep_object_large() -> Value {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let parsed = Jqesque::from_str_with_options(
+        "~root.a.b.c={\"k01\":1,\"k02\":2,\"k03\":3,\"k04\":4,\"k05\":5,\"k06\":6,\"k07\":7,\"k08\":8}",
+        options,
+    )
+    .expect("parse ok");
+
+    let mut json_obj = json!({
+        "root": {
+            "a": {
+                "b": {
+                    "c": {
+                        "keep": true,
+                        "k00": 0
+                    }
+                }
+            }
+        }
+    });
+
+    parsed.apply_to(&mut json_obj).expect("apply ok");
+    json_obj
+}
+
+library_benchmark_group!(
+    name = merge_deep_object_large_group;
+    benchmarks = merge_deep_object_large
+);
+main!(library_benchmark_groups = merge_deep_object_large_group);

--- a/benches/merge_object_small_callgrind.rs
+++ b/benches/merge_object_small_callgrind.rs
@@ -1,0 +1,24 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+use serde_json::{json, Value};
+
+#[library_benchmark]
+fn merge_object_small() -> Value {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let parsed = Jqesque::from_str_with_options(
+        "~settings.theme={\"color\":\"blue\",\"font\":\"sans\"}",
+        options,
+    )
+    .expect("parse ok");
+
+    let mut json_obj = json!({"settings": {"theme": {"color": "red", "size": 12}}});
+    parsed.apply_to(&mut json_obj).expect("apply ok");
+    json_obj
+}
+
+library_benchmark_group!(name = merge_object_small_group; benchmarks = merge_object_small);
+main!(library_benchmark_groups = merge_object_small_group);

--- a/benches/parse_array_medium_callgrind.rs
+++ b/benches/parse_array_medium_callgrind.rs
@@ -1,0 +1,17 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+
+#[library_benchmark]
+fn parse_array_medium() -> Option<usize> {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let input = ">items=[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32]";
+    let parsed = Jqesque::from_str_with_options(input, options).ok()?;
+    Some(parsed.tokens().len())
+}
+
+library_benchmark_group!(name = parse_array_medium_group; benchmarks = parse_array_medium);
+main!(library_benchmark_groups = parse_array_medium_group);

--- a/benches/parse_deep_path_medium_callgrind.rs
+++ b/benches/parse_deep_path_medium_callgrind.rs
@@ -1,0 +1,20 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+
+#[library_benchmark]
+fn parse_deep_path_medium() -> Option<usize> {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let input = ">a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p=1";
+    let parsed = Jqesque::from_str_with_options(input, options).ok()?;
+    Some(parsed.tokens().len())
+}
+
+library_benchmark_group!(
+    name = parse_deep_path_medium_group;
+    benchmarks = parse_deep_path_medium
+);
+main!(library_benchmark_groups = parse_deep_path_medium_group);

--- a/benches/parse_object_large_callgrind.rs
+++ b/benches/parse_object_large_callgrind.rs
@@ -1,0 +1,17 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+
+#[library_benchmark]
+fn parse_object_large() -> Option<usize> {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let input = ">settings={\"k01\":1,\"k02\":2,\"k03\":3,\"k04\":4,\"k05\":5,\"k06\":6,\"k07\":7,\"k08\":8,\"k09\":9,\"k10\":10,\"k11\":11,\"k12\":12,\"k13\":13,\"k14\":14,\"k15\":15,\"k16\":16}";
+    let parsed = Jqesque::from_str_with_options(input, options).ok()?;
+    Some(parsed.tokens().len())
+}
+
+library_benchmark_group!(name = parse_object_large_group; benchmarks = parse_object_large);
+main!(library_benchmark_groups = parse_object_large_group);

--- a/benches/parse_scalar_small_callgrind.rs
+++ b/benches/parse_scalar_small_callgrind.rs
@@ -1,0 +1,16 @@
+use iai_callgrind::{library_benchmark, library_benchmark_group, main};
+use jqesque::{Jqesque, ParseOptions, Separator};
+
+#[library_benchmark]
+fn parse_scalar_small() -> Option<usize> {
+    let options = ParseOptions::new(Separator::Dot)
+        .strict_json_values(false)
+        .max_path_depth(64)
+        .max_array_index(10_000);
+
+    let parsed = Jqesque::from_str_with_options(">a=1", options).ok()?;
+    Some(parsed.tokens().len())
+}
+
+library_benchmark_group!(name = parse_scalar_small_group; benchmarks = parse_scalar_small);
+main!(library_benchmark_groups = parse_scalar_small_group);

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,11 @@
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/RustSec/advisory-db"]
 yanked = "warn"
+ignore = [
+	# Transitive dev-only dependency from iai-callgrind.
+	# No upstream-safe replacement is currently available in that chain.
+	"RUSTSEC-2025-0141",
+]
 
 [bans]
 multiple-versions = "warn"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,13 @@
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/RustSec/advisory-db"]
+yanked = "warn"
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "jqesque-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+
+[dependencies.jqesque]
+path = ".."
+
+[[bin]]
+name = "parse_apply"
+path = "fuzz_targets/parse_apply.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "deep_paths_indices"
+path = "fuzz_targets/deep_paths_indices.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/deep_paths_indices.rs
+++ b/fuzz/fuzz_targets/deep_paths_indices.rs
@@ -1,0 +1,36 @@
+#![no_main]
+
+use jqesque::{Jqesque, ParseOptions, Separator};
+use libfuzzer_sys::fuzz_target;
+use serde_json::json;
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+
+    let depth = (data[0] as usize % 300) + 1;
+    let index = data.iter().skip(1).fold(0usize, |acc, b| {
+        acc.saturating_mul(10).saturating_add((b % 10) as usize)
+    });
+
+    let path = std::iter::repeat_n("a", depth)
+        .collect::<Vec<_>>()
+        .join(".");
+    let input = format!(">{}[{}]=1", path, index);
+
+    for separator in [Separator::Dot, Separator::Slash, Separator::Custom(':')] {
+        let options = ParseOptions::new(separator)
+            .strict_json_values(false)
+            .max_path_depth(64)
+            .max_array_index(50_000);
+
+        if let Ok(parsed) = Jqesque::from_str_with_options(&input, options) {
+            let mut json_obj = json!({
+                "seed": [1, 2, 3],
+                "settings": { "theme": "light" }
+            });
+            let _ = parsed.apply_to(&mut json_obj);
+        }
+    }
+});

--- a/fuzz/fuzz_targets/parse_apply.rs
+++ b/fuzz/fuzz_targets/parse_apply.rs
@@ -1,0 +1,26 @@
+#![no_main]
+
+use jqesque::{Jqesque, ParseOptions, Separator};
+use libfuzzer_sys::fuzz_target;
+use serde_json::json;
+
+fuzz_target!(|data: &[u8]| {
+    let input = String::from_utf8_lossy(data);
+
+    for separator in [Separator::Dot, Separator::Slash, Separator::Custom(':')] {
+        let options = ParseOptions::new(separator)
+            .strict_json_values(false)
+            .max_path_depth(64)
+            .max_array_index(50_000);
+
+        if let Ok(parsed) = Jqesque::from_str_with_options(&input, options) {
+            let mut json_obj = json!({
+                "seed": [1, 2, 3],
+                "settings": { "theme": "light" }
+            });
+
+            let _ = parsed.as_json();
+            let _ = parsed.apply_to(&mut json_obj);
+        }
+    }
+});

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
+cargo test --doc --all-features
+
+if command -v cargo-deny >/dev/null 2>&1; then
+  cargo deny check advisories bans sources
+else
+  echo "cargo-deny not installed; skipping (cargo install cargo-deny --locked)"
+fi
+
+if command -v cargo-audit >/dev/null 2>&1; then
+  cargo audit
+else
+  echo "cargo-audit not installed; skipping (cargo install cargo-audit --locked)"
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,8 +56,12 @@
 //! let jqesque = input.parse::<Jqesque>().unwrap();
 //! // Without using turbofish syntax:
 //! // let jqesque: Jqesque = input.parse().unwrap();
-//! // Alternatively, if you want to specify the separator:
-//! // let jqesque = Jqesque::from_str_with_separator(input, Separator::Dot).unwrap();
+//! // Recommended for untrusted input:
+//! // let options = ParseOptions::new(Separator::Dot)
+//! //     .strict_json_values(true)
+//! //     .max_path_depth(64)
+//! //     .max_array_index(10_000);
+//! // let jqesque = Jqesque::from_str_with_options(input, options).unwrap();
 //!
 //! let json_output = jqesque.as_json();
 //! assert_eq!(json_output, json!({
@@ -74,11 +78,15 @@
 //! ### Specifying the separator
 //!
 //! ```rust
-//! use jqesque::{Jqesque, Separator};
+//! use jqesque::{Jqesque, ParseOptions, Separator};
 //! use serde_json::json;
 //!
 //! let input = ">foo/bar[0]/baz=true";
-//! let jqesque = Jqesque::from_str_with_separator(input, Separator::Slash).unwrap();
+//! let options = ParseOptions::new(Separator::Slash)
+//!     .strict_json_values(true)
+//!     .max_path_depth(64)
+//!     .max_array_index(10_000);
+//! let jqesque = Jqesque::from_str_with_options(input, options).unwrap();
 //! let json_output = jqesque.as_json();
 //!
 //! assert_eq!(json_output, json!({
@@ -96,7 +104,7 @@
 //!
 //! ```rust
 //! use serde_json::json;
-//! use jqesque::{Jqesque, Separator};
+//! use jqesque::{Jqesque, ParseOptions, Separator};
 //!
 //! let mut json_obj = json!({
 //!     "settings": {
@@ -109,7 +117,11 @@
 //! });
 //!
 //! let input = ">settings.theme={\"color\":\"blue\",\"font\":\"Helvetica\"}";
-//! let jqesque = Jqesque::from_str_with_separator(input, Separator::Dot).unwrap();
+//! let options = ParseOptions::new(Separator::Dot)
+//!     .strict_json_values(true)
+//!     .max_path_depth(64)
+//!     .max_array_index(10_000);
+//! let jqesque = Jqesque::from_str_with_options(input, options).unwrap();
 //!
 //! jqesque.apply_to(&mut json_obj);
 //!
@@ -137,7 +149,7 @@
 //!
 //! ```rust
 //! use serde_json::json;
-//! use jqesque::{Jqesque, Separator};
+//! use jqesque::{Jqesque, ParseOptions, Separator};
 //!
 //! let mut json_obj = json!({
 //!     "settings": {
@@ -150,7 +162,11 @@
 //! });
 //!
 //! let input = "~settings.theme={\"color\":\"blue\",\"font\":\"Helvetica\"}";
-//! let jqesque = Jqesque::from_str_with_separator(input, Separator::Dot).unwrap();
+//! let options = ParseOptions::new(Separator::Dot)
+//!     .strict_json_values(true)
+//!     .max_path_depth(64)
+//!     .max_array_index(10_000);
+//! let jqesque = Jqesque::from_str_with_options(input, options).unwrap();
 //!
 //! jqesque.apply_to(&mut json_obj);
 //!
@@ -176,4 +192,7 @@ mod manipulators;
 mod parse;
 mod types;
 
-pub use types::{Jqesque, JqesqueError, Operation, PathToken, Separator};
+pub use types::{
+    Jqesque, JqesqueError, Operation, ParseOptions, PathToken, Separator, DEFAULT_MAX_ARRAY_INDEX,
+    DEFAULT_MAX_PATH_DEPTH,
+};

--- a/src/manipulators.rs
+++ b/src/manipulators.rs
@@ -10,9 +10,7 @@ use serde_json::{Map, Value};
 /// * `json_obj` - The JSON object to insert into.
 /// * `tokens` - The path tokens representing where to insert.
 /// * `value` - The value to insert.
-pub fn insert_value(json_obj: &mut Value, tokens: &[PathToken], value: &Option<Value>) {
-    let value = value.as_ref().unwrap_or(&Value::Null);
-
+pub fn insert_value(json_obj: &mut Value, tokens: &[PathToken], value: &Value) {
     if tokens.is_empty() {
         *json_obj = value.clone();
         return;
@@ -28,7 +26,7 @@ pub fn insert_value(json_obj: &mut Value, tokens: &[PathToken], value: &Option<V
                 .unwrap()
                 .entry(key.clone())
                 .or_insert(Value::Null);
-            insert_value(entry, &tokens[1..], &Some(value.clone()));
+            insert_value(entry, &tokens[1..], value);
         }
         PathToken::Index(index) => {
             if !json_obj.is_array() {
@@ -39,7 +37,7 @@ pub fn insert_value(json_obj: &mut Value, tokens: &[PathToken], value: &Option<V
             if *index >= array.len() {
                 array.resize(*index + 1, Value::Null);
             }
-            insert_value(&mut array[*index], &tokens[1..], &Some(value.clone()));
+            insert_value(&mut array[*index], &tokens[1..], value);
         }
     }
 }
@@ -72,11 +70,12 @@ pub fn merge_json(a: &mut Value, b: &mut Value) {
     }
 }
 
+#[cfg(test)]
 mod test {
     #[allow(unused_imports)]
     use super::{insert_value, merge_json};
+    use rstest::rstest;
     use serde_json::json;
-    use yare::parameterized;
 
     #[allow(unused_imports)]
     use crate::{Jqesque, JqesqueError, PathToken, Separator};
@@ -88,12 +87,20 @@ mod test {
         })
     }
 
-    #[parameterized(
-        new_keys = { json!({"key2": "value2"}), json!({"key": "value", "key2": "value2"}) },
-        nested_keys = { json!({"parent": {"child": "value"}}), json!({"key": "value", "parent": {"child": "value"}}) },
-        nested_array = { json!({"array": [1]}), json!({"key": "value", "array": [1]}) },
+    #[rstest]
+    #[case::new_keys(
+        json!({"key2": "value2"}),
+        json!({"key": "value", "key2": "value2"})
     )]
-    fn test_merge_json_ok(new_data: serde_json::Value, expected: serde_json::Value) {
+    #[case::nested_keys(
+        json!({"parent": {"child": "value"}}),
+        json!({"key": "value", "parent": {"child": "value"}})
+    )]
+    #[case::nested_array(json!({"array": [1]}), json!({"key": "value", "array": [1]}))]
+    fn test_merge_json_ok(
+        #[case] new_data: serde_json::Value,
+        #[case] expected: serde_json::Value,
+    ) {
         let mut json_obj = base_json();
         let mut new_data = new_data;
         merge_json(&mut json_obj, &mut new_data);
@@ -101,15 +108,18 @@ mod test {
         assert_eq!(json_obj, expected);
     }
 
-    #[parameterized(
-        empty_path = { vec![], json!("value"), json!("value") },
-        single_key = { vec!["key"], json!("value"), json!({"key": "value"}) },
-        nested_keys = { vec!["key2", "key3"], json!("value"), json!({"key2": {"key3": "value"}}) },
+    #[rstest]
+    #[case::empty_path(vec![], json!("value"), json!("value"))]
+    #[case::single_key(vec!["key"], json!("value"), json!({"key": "value"}))]
+    #[case::nested_keys(
+        vec!["key2", "key3"],
+        json!("value"),
+        json!({"key2": {"key3": "value"}})
     )]
     fn test_insert_value_ok(
-        tokens: Vec<&str>,
-        value: serde_json::Value,
-        expected: serde_json::Value,
+        #[case] tokens: Vec<&str>,
+        #[case] value: serde_json::Value,
+        #[case] expected: serde_json::Value,
     ) {
         let mut json_obj = serde_json::Value::Null;
         let tokens: Vec<_> = tokens
@@ -117,27 +127,58 @@ mod test {
             .map(|s| s.to_string())
             .map(PathToken::Key)
             .collect();
-        insert_value(&mut json_obj, &tokens, &Some(value));
+        insert_value(&mut json_obj, &tokens, &value);
 
         assert_eq!(json_obj, expected);
     }
 
-    #[parameterized(
-    negative_index = { "arr[-1]=value", Separator::Dot, JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"[-1]=value\", Char('='))] }".to_string()) },
-    invalid_index = { "arr[invalid]=value", Separator::Dot, JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"[invalid]=value\", Char('='))] }".to_string())}, 
-    missing_value = { "key=", Separator::Dot, JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"\", Nom(IsNot))] }".to_string()) },
-    missing_key = { "=value", Separator::Dot, JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"\", Char('='))] }".to_string()) },
-    missing_assignment = { "key", Separator::Dot, JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"\", Char('='))] }".to_string()) },
-    illegal_operator = { "!key=value", Separator::Dot, JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"!key=value\", Nom(TakeWhile1)), (\"!key=value\", Nom(Alt)), (\"!key=value\", Nom(Alt))] }".to_string()) },
-)]
-    fn test_parse_input_err(input: &str, separator: Separator, expected: JqesqueError) {
+    #[rstest]
+    #[case::negative_index(
+        "arr[-1]=value",
+        Separator::Dot,
+        JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"[-1]=value\", Char('='))] }".to_string())
+    )]
+    #[case::invalid_index(
+        "arr[invalid]=value",
+        Separator::Dot,
+        JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"[invalid]=value\", Char('='))] }".to_string())
+    )]
+    #[case::missing_value(
+        "key=",
+        Separator::Dot,
+        JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"\", Nom(IsNot))] }".to_string())
+    )]
+    #[case::missing_key(
+        "=value",
+        Separator::Dot,
+        JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"\", Char('='))] }".to_string())
+    )]
+    #[case::missing_assignment(
+        "key",
+        Separator::Dot,
+        JqesqueError::NomError("Parsing Error: VerboseError { errors: [(\"\", Char('='))] }".to_string())
+    )]
+    #[case::illegal_operator(
+        "!key=value",
+        Separator::Dot,
+        JqesqueError::NomError(
+            "Parsing Error: VerboseError { errors: [(\"!key=value\", Nom(TakeWhile1)), (\"!key=value\", Nom(Alt)), (\"!key=value\", Nom(Alt))] }"
+                .to_string()
+        )
+    )]
+    fn test_parse_input_err(
+        #[case] input: &str,
+        #[case] separator: Separator,
+        #[case] expected: JqesqueError,
+    ) {
         let result = Jqesque::from_str_with_separator(input, separator);
 
         match result {
             Ok(_) => {
                 let parsed = result.unwrap();
                 let mut json_obj = serde_json::Value::Null;
-                insert_value(&mut json_obj, parsed.tokens(), parsed.value());
+                let value = parsed.value().clone().unwrap_or(serde_json::Value::Null);
+                insert_value(&mut json_obj, parsed.tokens(), &value);
                 panic!(
                     "Expected an error, but got Ok (tokens: {:?} -> json_obj: {})",
                     parsed.tokens(),

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -1,4 +1,4 @@
-use crate::types::{Jqesque, JqesqueError, Operation, PathToken, Separator};
+use crate::types::{Jqesque, JqesqueError, Operation, ParseOptions, PathToken, Separator};
 use nom::{
     branch::alt,
     bytes::complete::{escaped_transform, is_not, take_while1},
@@ -24,27 +24,43 @@ type Res<T, U> = IResult<T, U, VerboseError<T>>;
 ///
 /// Returns a `Jqesque` structure if successful, or a `JqesqueError` if parsing fails.
 pub fn parse_input(input: &str, separator: Separator) -> Result<Jqesque, JqesqueError> {
-    let sep_char = separator.as_char();
-    let res = all_consuming(|i| jqesque(i, sep_char)).parse(input);
+    parse_input_with_options(input, ParseOptions::new(separator))
+}
+
+pub fn parse_input_with_options(
+    input: &str,
+    options: ParseOptions,
+) -> Result<Jqesque, JqesqueError> {
+    let sep_char = options.separator().as_char();
+    let strict_json_values = options.strict_json_values_enabled();
+    let res = all_consuming(|i| jqesque(i, sep_char, strict_json_values)).parse(input);
     match res {
-        Ok((_, jqesque)) => Ok(jqesque),
-        Err(err) => Err(JqesqueError::NomError(format!("{}", err))),
+        Ok((_, jqesque)) => {
+            jqesque.validate_limits(
+                options.max_path_depth_limit(),
+                options.max_array_index_limit(),
+            )?;
+            Ok(jqesque)
+        }
+        Err(err) => {
+            let err_msg = format!("{}", err);
+            if strict_json_values && err_msg.contains("Invalid JSON value in strict mode:") {
+                return Err(JqesqueError::InvalidJsonValueError(err_msg));
+            }
+            Err(JqesqueError::NomError(err_msg))
+        }
     }
 }
 
-fn jqesque(input: &str, separator: char) -> Res<&str, Jqesque> {
+fn jqesque(input: &str, separator: char, strict_json_values: bool) -> Res<&str, Jqesque> {
     let (input, operation) = opt(operation_prefix).parse(input)?;
     let operation = operation.unwrap_or(Operation::Auto);
 
-    let (input, (tokens, value)) = assignment(input, separator, &operation)?;
+    let (input, (tokens, value)) = assignment(input, separator, &operation, strict_json_values)?;
 
     Ok((
         input,
-        Jqesque {
-            operation,
-            tokens,
-            value,
-        },
+        Jqesque::from_parts_unchecked(tokens, value, operation),
     ))
 }
 
@@ -59,6 +75,7 @@ fn assignment<'a>(
     input: &'a str,
     separator: char,
     operation: &Operation,
+    strict_json_values: bool,
 ) -> Res<&'a str, (Vec<PathToken>, Option<Value>)> {
     let (input, tokens) = path(input, separator)?;
 
@@ -67,7 +84,7 @@ fn assignment<'a>(
         _ => {
             let (input, _) = char('=')(input)?;
             let (input, _) = opt(char(' ')).parse(input)?;
-            let (input, value) = json_value(input)?;
+            let (input, value) = json_value(input, strict_json_values)?;
             (input, Some(value))
         }
     };
@@ -131,9 +148,14 @@ fn quoted_string(input: &str) -> Res<&str, String> {
     .parse(input)
 }
 
-fn json_value(input: &str) -> Res<&str, Value> {
-    map(is_not(""), |s: &str| {
-        serde_json::from_str(s).unwrap_or(Value::String(s.to_string()))
+fn json_value(input: &str, strict_json_values: bool) -> Res<&str, Value> {
+    map_res(is_not(""), move |s: &str| {
+        if strict_json_values {
+            serde_json::from_str::<Value>(s)
+                .map_err(|e| format!("Invalid JSON value in strict mode: {e}"))
+        } else {
+            Ok(serde_json::from_str(s).unwrap_or(Value::String(s.to_string())))
+        }
     })
     .parse(input)
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,16 +8,69 @@ use serde_json::{json, Value};
 use thiserror::Error;
 
 use crate::manipulators::{insert_value, merge_json};
-use crate::parse::parse_input;
+use crate::parse::{parse_input, parse_input_with_options};
+
+pub const DEFAULT_MAX_PATH_DEPTH: usize = 128;
+pub const DEFAULT_MAX_ARRAY_INDEX: usize = 1_000_000;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ParseOptions {
+    separator: Separator,
+    strict_json_values: bool,
+    max_path_depth: usize,
+    max_array_index: usize,
+}
+
+impl ParseOptions {
+    pub fn new(separator: Separator) -> Self {
+        Self {
+            separator,
+            strict_json_values: false,
+            max_path_depth: DEFAULT_MAX_PATH_DEPTH,
+            max_array_index: DEFAULT_MAX_ARRAY_INDEX,
+        }
+    }
+
+    pub fn strict_json_values(mut self, strict_json_values: bool) -> Self {
+        self.strict_json_values = strict_json_values;
+        self
+    }
+
+    pub fn max_path_depth(mut self, max_path_depth: usize) -> Self {
+        self.max_path_depth = max_path_depth;
+        self
+    }
+
+    pub fn max_array_index(mut self, max_array_index: usize) -> Self {
+        self.max_array_index = max_array_index;
+        self
+    }
+
+    pub fn separator(&self) -> Separator {
+        self.separator
+    }
+
+    pub fn strict_json_values_enabled(&self) -> bool {
+        self.strict_json_values
+    }
+
+    pub fn max_path_depth_limit(&self) -> usize {
+        self.max_path_depth
+    }
+
+    pub fn max_array_index_limit(&self) -> usize {
+        self.max_array_index
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Jqesque {
     // The path tokens representing the path to the value (the left-hand side of the assignment)
-    pub tokens: Vec<PathToken>,
+    tokens: Vec<PathToken>,
     // The value itself (the right-hand side of the assignment)
-    pub value: Option<Value>,
+    value: Option<Value>,
     // The operation to perform
-    pub operation: Operation,
+    operation: Operation,
 }
 
 impl FromStr for Jqesque {
@@ -50,7 +103,33 @@ impl FromStr for Jqesque {
 }
 
 impl Jqesque {
+    pub(crate) fn from_parts_unchecked(
+        tokens: Vec<PathToken>,
+        value: Option<Value>,
+        operation: Operation,
+    ) -> Self {
+        Self {
+            tokens,
+            value,
+            operation,
+        }
+    }
+
+    pub fn new(
+        tokens: Vec<PathToken>,
+        value: Option<Value>,
+        operation: Operation,
+    ) -> Result<Self, JqesqueError> {
+        let jq = Self::from_parts_unchecked(tokens, value, operation);
+        jq.validate_limits(DEFAULT_MAX_PATH_DEPTH, DEFAULT_MAX_ARRAY_INDEX)?;
+        Ok(jq)
+    }
+
     /// Parses an input string into a `Jqesque` structure using the specified separator.
+    ///
+    /// This is a convenience API for trusted or simple inputs.
+    /// For untrusted input, prefer `from_str_with_options` so you can configure
+    /// strict parsing and resource limits.
     ///
     /// ## Arguments
     ///
@@ -92,6 +171,28 @@ impl Jqesque {
         parse_input(input, separator)
     }
 
+    /// Parses an input string into a `Jqesque` structure using parse options.
+    ///
+    /// This is the recommended API for untrusted input because it allows
+    /// strict JSON value parsing and configurable safety limits.
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use jqesque::{Jqesque, ParseOptions, Separator};
+    ///
+    /// let options = ParseOptions::new(Separator::Dot)
+    ///     .strict_json_values(true)
+    ///     .max_path_depth(64)
+    ///     .max_array_index(10_000);
+    ///
+    /// let jqesque = Jqesque::from_str_with_options("foo.bar=\"baz\"", options).unwrap();
+    /// assert_eq!(jqesque.tokens().len(), 2);
+    /// ```
+    pub fn from_str_with_options(input: &str, options: ParseOptions) -> Result<Self, JqesqueError> {
+        parse_input_with_options(input, options)
+    }
+
     /// Returns the path tokens of the parsed structure.
     pub fn tokens(&self) -> &[PathToken] {
         &self.tokens
@@ -126,6 +227,11 @@ impl Jqesque {
     /// ```
     pub fn value(&self) -> &Option<Value> {
         &self.value
+    }
+
+    /// Returns the parsed operation.
+    pub fn operation(&self) -> &Operation {
+        &self.operation
     }
 
     /// Converts the parsed structure into a new JSON object.
@@ -167,7 +273,8 @@ impl Jqesque {
             Operation::Merge | Operation::Insert => {
                 // For merge and insert, return the value to be merged or inserted
                 let mut json_obj = Value::Null;
-                insert_value(&mut json_obj, &self.tokens, &self.value);
+                let value = self.value.as_ref().unwrap_or(&Value::Null);
+                insert_value(&mut json_obj, &self.tokens, value);
                 json_obj
             }
         }
@@ -186,6 +293,8 @@ impl Jqesque {
     ///
     /// Returns the operation that was performed or a JqesqueError if an error occurred.
     pub fn apply_to(&self, json: &mut Value) -> Result<Operation, JqesqueError> {
+        self.validate_limits(DEFAULT_MAX_PATH_DEPTH, DEFAULT_MAX_ARRAY_INDEX)?;
+
         match self.operation {
             Operation::Auto => {
                 // Try Replace
@@ -265,16 +374,53 @@ impl Jqesque {
             Operation::Merge => {
                 // Assuming no errors occur during merge
                 let mut temp_value = Value::Null;
-                insert_value(&mut temp_value, &self.tokens, &self.value);
+                let value = self.value.as_ref().unwrap_or(&Value::Null);
+                insert_value(&mut temp_value, &self.tokens, value);
                 merge_json(json, &mut temp_value);
                 Ok(Operation::Merge)
             }
             Operation::Insert => {
                 // Assuming no errors occur during insert
-                insert_value(json, &self.tokens, &self.value);
+                let value = self.value.as_ref().unwrap_or(&Value::Null);
+                insert_value(json, &self.tokens, value);
                 Ok(Operation::Insert)
             }
         }
+    }
+
+    pub fn validate_limits(
+        &self,
+        max_path_depth: usize,
+        max_array_index: usize,
+    ) -> Result<(), JqesqueError> {
+        if self.tokens.len() > max_path_depth {
+            return Err(JqesqueError::LimitExceededError {
+                kind: "path depth",
+                limit: max_path_depth,
+                found: self.tokens.len(),
+            });
+        }
+
+        let max_found_index = self
+            .tokens
+            .iter()
+            .filter_map(|token| match token {
+                PathToken::Index(index) => Some(*index),
+                _ => None,
+            })
+            .max();
+
+        if let Some(index) = max_found_index {
+            if index > max_array_index {
+                return Err(JqesqueError::LimitExceededError {
+                    kind: "array index",
+                    limit: max_array_index,
+                    found: index,
+                });
+            }
+        }
+
+        Ok(())
     }
 
     /// Converts the path tokens to a JSON Pointer.
@@ -557,4 +703,14 @@ pub enum JqesqueError {
 
     #[error("Failed to access path: {0}")]
     InvalidPathError(String),
+
+    #[error("Invalid JSON value in strict mode: {0}")]
+    InvalidJsonValueError(String),
+
+    #[error("Limit exceeded for {kind}: limit={limit}, found={found}")]
+    LimitExceededError {
+        kind: &'static str,
+        limit: usize,
+        found: usize,
+    },
 }

--- a/tests/jqesque.rs
+++ b/tests/jqesque.rs
@@ -1,12 +1,16 @@
-use jqesque::{Jqesque, JqesqueError, Operation, Separator};
+use jqesque::{
+    Jqesque, JqesqueError, Operation, ParseOptions, PathToken, Separator, DEFAULT_MAX_ARRAY_INDEX,
+};
+use rstest::rstest;
 use serde_json::json;
-use yare::parameterized;
 
-#[parameterized(
-    simple_key = { "key=value", json!({"key": "value"}) } ,
-    nested_keys = { "parent.child=value", json!({"parent": {"child": "value"}}) },
-)]
-fn test_using_from_str_with_default_separator(input: &str, expected: serde_json::Value) {
+#[rstest]
+#[case("key=value", json!({"key": "value"}))]
+#[case("parent.child=value", json!({"parent": {"child": "value"}}))]
+fn test_using_from_str_with_default_separator(
+    #[case] input: &str,
+    #[case] expected: serde_json::Value,
+) {
     let parsed = input.parse::<Jqesque>().expect("Failed to parse input");
 
     let mut json_obj = serde_json::Value::Null;
@@ -15,45 +19,33 @@ fn test_using_from_str_with_default_separator(input: &str, expected: serde_json:
     assert_eq!(json_obj, expected);
 }
 
-// Tests for the `Insert` operation that should **succeed**.
-#[allow(clippy::approx_constant)] // Since we use 3.14 as a test value
-#[parameterized(
-    simple_key = { ">key=value", Separator::Dot, json!({"key": "value"}) },
-    nested_keys = { ">parent.child=value", Separator::Dot, json!({"parent": {"child": "value"}}) },
-    array_index = { ">array[0]=1", Separator::Dot, json!({"array": [1]}) },
-    nested_array = { ">array[0][1]=2", Separator::Dot, json!({"array": [[null, 2]]}) },
-    custom_separator = { ">key1/key2=value", Separator::Slash, json!({"key1": {"key2": "value"}}) },
-    quoted_key = { ">\"complex.key\"=123", Separator::Dot, json!({"complex.key": 123}) },
-    bool_value = { ">flag=true", Separator::Dot, json!({"flag": true}) },
-    null_value = { ">nothing=null", Separator::Dot, json!({"nothing": null}) },
-    number_value = { ">number=42", Separator::Dot, json!({"number": 42}) },
-    float_value = { ">pi=3.14", Separator::Dot, json!({"pi": 3.14}) },
-    complex_path = { ">foo[1].bar[2]=value", Separator::Dot, json!({"foo": [null, {"bar": [null, null, "value"]}]}) },
-    key_with_spaces = { ">\"key with spaces\"=value", Separator::Dot, json!({"key with spaces": "value"}) },
-    array_of_objects = { ">items[0].name=Item1", Separator::Dot, json!({"items": [{"name": "Item1"}]}) },
-    nested_objects = { ">obj.level1.level2=value", Separator::Dot, json!({"obj": {"level1": {"level2": "value"}}}) },
-    empty_string_value = { ">empty=\"\"", Separator::Dot, json!({"empty": ""}) },
-    special_chars_in_key = { ">\"key!@#$%^&*()\"=value", Separator::Dot, json!({"key!@#$%^&*()": "value"}) },
-    unicode_key = { ">\"ключ\"=значение", Separator::Dot, json!({"ключ": "значение"}) },
-    multiple_arrays = { ">a[0][1][2]=value", Separator::Dot, json!({
-        "a": [
-            [ // a[0]
-                null,
-                [ // a[0][1]
-                    null,
-                    null,
-                    "value"
-                ]
-            ]
-        ]
-    }),
-    },
-    example_from_readme = { ">foo.bar[0].baz=true", Separator::Dot, json!({"foo": {"bar": [{"baz": true}]}}) },
-    array_assignment_numbers = { ">arr=[1,2,3]", Separator::Dot, json!({"arr": [1, 2, 3]}) },
-    array_assignment_text = { ">arr=[\"a\",\"b\",\"c\"]", Separator::Dot, json!({"arr": ["a", "b", "c"]}) },
-    array_assignment_text_raw = { r#">arr=["a","b","c"]"#, Separator::Dot, json!({"arr": ["a", "b", "c"]}) },
-)]
-fn test_parse_input_insert_ok(input: &str, separator: Separator, expected: serde_json::Value) {
+#[rstest]
+#[case(">key=value", Separator::Dot, json!({"key": "value"}))]
+#[case(">parent.child=value", Separator::Dot, json!({"parent": {"child": "value"}}))]
+#[case(">array[0]=1", Separator::Dot, json!({"array": [1]}))]
+#[case(">array[0][1]=2", Separator::Dot, json!({"array": [[null, 2]]}))]
+#[case(">key1/key2=value", Separator::Slash, json!({"key1": {"key2": "value"}}))]
+#[case(">\"complex.key\"=123", Separator::Dot, json!({"complex.key": 123}))]
+#[case(">flag=true", Separator::Dot, json!({"flag": true}))]
+#[case(">nothing=null", Separator::Dot, json!({"nothing": null}))]
+#[case(">number=42", Separator::Dot, json!({"number": 42}))]
+#[case(">pi=3.14", Separator::Dot, json!({"pi": 314_f64 / 100.0}))]
+#[case(">foo[1].bar[2]=value", Separator::Dot, json!({"foo": [null, {"bar": [null, null, "value"]}]}))]
+#[case(">\"key with spaces\"=value", Separator::Dot, json!({"key with spaces": "value"}))]
+#[case(">items[0].name=Item1", Separator::Dot, json!({"items": [{"name": "Item1"}]}))]
+#[case(">obj.level1.level2=value", Separator::Dot, json!({"obj": {"level1": {"level2": "value"}}}))]
+#[case(">empty=\"\"", Separator::Dot, json!({"empty": ""}))]
+#[case(">\"key!@#$%^&*()\"=value", Separator::Dot, json!({"key!@#$%^&*()": "value"}))]
+#[case(">\"ключ\"=значение", Separator::Dot, json!({"ключ": "значение"}))]
+#[case(">foo.bar[0].baz=true", Separator::Dot, json!({"foo": {"bar": [{"baz": true}]}}))]
+#[case(">arr=[1,2,3]", Separator::Dot, json!({"arr": [1, 2, 3]}))]
+#[case(">arr=[\"a\",\"b\",\"c\"]", Separator::Dot, json!({"arr": ["a", "b", "c"]}))]
+#[case(r#">arr=["a","b","c"]"#, Separator::Dot, json!({"arr": ["a", "b", "c"]}))]
+fn test_parse_input_insert_ok(
+    #[case] input: &str,
+    #[case] separator: Separator,
+    #[case] expected: serde_json::Value,
+) {
     let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
 
     let mut json_obj = serde_json::Value::Null;
@@ -62,365 +54,166 @@ fn test_parse_input_insert_ok(input: &str, separator: Separator, expected: serde
     assert_eq!(json_obj, expected);
 }
 
-// Tests for the `Add` operation that should **succeed**.
-#[parameterized(
-    add_to_existing_object = {
-        "+parent.child.key=value", Separator::Dot,
-        json!({
-            "parent": {
-                "child": {
-                    "key": "value"
-                }
-            },
-            "array": [1, 2, 3]
-        })
-    },
-    add_to_existing_array = {
-        "+array/1=42", Separator::Slash,
-        json!({
-            "parent": {
-                "child": {}
-            },
-            "array": [1, 42, 2, 3]
-        })
-    },
-    add_to_end_of_array = {
-        "+array/-=99", Separator::Slash,
-        json!({
-            "parent": {
-                "child": {}
-            },
-            "array": [1, 2, 3, 99]
-        })
-    },
-)]
-fn test_add_operation_success(input: &str, separator: Separator, expected: serde_json::Value) {
-    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
-    assert_eq!(parsed.operation, Operation::Add);
-
-    let mut json_obj = json!({
-        "parent": {
-            "child": {}
-        },
-        "array": [1, 2, 3]
-    });
-
-    parsed.apply_to(&mut json_obj).unwrap();
-
-    assert_eq!(json_obj, expected);
-}
-
-// Tests for the `Add` operation that should **fail**.
-#[parameterized(
-    add_to_nonexistent_object = {
-        "+nonexistent.key=value", Separator::Dot
-    },
-    add_to_nonexistent_array = {
-        "+nonexistent_array/0=value", Separator::Slash
-    },
-    add_with_invalid_index = {
-        "+array/10=value", Separator::Slash
-    },
-)]
-fn test_add_operation_failure(input: &str, separator: Separator) {
-    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
-    assert_eq!(parsed.operation, Operation::Add);
-
-    let mut json_obj = json!({
-        "parent": {
-            "child": {}
-        },
-        "array": [1, 2, 3]
-    });
-
-    let result = parsed.apply_to(&mut json_obj);
-    assert!(result.is_err(), "Expected error but operation succeeded");
-}
-
-// Tests for the `Replace` operation that should **succeed**.
-#[parameterized(
-    replace_existing_key = {
-        "=parent.child.key=new_value", Separator::Dot,
-        json!({
-            "parent": {
-                "child": {
-                    "key": "new_value"
-                }
-            },
-            "array": [1, 2, 3],
-            "root": "root_value"
-        })
-    },
-    replace_array_element = {
-        "=array/1=42", Separator::Slash,
-        json!({
-            "parent": {
-                "child": {
-                    "key": "old_value"
-                }
-            },
-            "array": [1, 42, 3],
-            "root": "root_value"
-        })
-    },
-    replace_root_key = {
-        "=root=new_root_value", Separator::Dot,
-        json!({
-            "parent": {
-                "child": {
-                    "key": "old_value"
-                }
-            },
-            "array": [1, 2, 3],
-            "root": "new_root_value"
-        })
-    },
-    replace_entire_object = {
-        "=parent={\"new\": \"object\"}", Separator::Dot,
-        json!({
-            "parent": {
-                "new": "object"
-            },
-            "array": [1, 2, 3],
-            "root": "root_value"
-        })
-    },
-    replace_with_null = {
-        "=parent.child.key=null", Separator::Dot,
-        json!({
-            "parent": {
-                "child": {
-                    "key": null
-                }
-            },
-            "array": [1, 2, 3],
-            "root": "root_value"
-        })
-    },
-)]
-fn test_replace_operation_success(input: &str, separator: Separator, expected: serde_json::Value) {
-    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
-    assert_eq!(parsed.operation, Operation::Replace);
-
-    let mut json_obj = json!({
-        "parent": {
-            "child": {
-                "key": "old_value"
-            }
-        },
-        "array": [1, 2, 3],
-        "root": "root_value"
-    });
-
-    parsed.apply_to(&mut json_obj).unwrap();
-
-    assert_eq!(json_obj, expected);
-}
-
-// Tests for the `Replace` operation that should **fail**.
-#[parameterized(
-    replace_nonexistent_key = {
-        "=parent.child.nonexistent_key=new_value", Separator::Dot
-    },
-    replace_nonexistent_array_element = {
-        "=array/10=42", Separator::Slash
-    },
-    replace_nonexistent_root_key = {
-        "=nonexistent_root_key=value", Separator::Dot
-    },
-    replace_in_non_object = {
-        "=array/1/key=value", Separator::Slash      // Trying to access key in an array element
-    },
-)]
-fn test_replace_operation_failure(input: &str, separator: Separator) {
-    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
-    assert_eq!(parsed.operation, Operation::Replace);
-
-    let mut json_obj = json!({
-        "parent": {
-            "child": {
-                "key": "old_value"
-            }
-        },
-        "array": [1, 2, 3],
-        "root": "root_value"
-    });
-
-    let result = parsed.apply_to(&mut json_obj);
-    assert!(result.is_err(), "Expected error but operation succeeded");
-}
-
-// Tests for the `Remove` operation that should **succeed**.
-#[parameterized(
-    remove_existing_key = {
-        "-existing_key", Separator::Dot,
-        json!({
-            "array": [1, 2, 3],
-            "nested": {
-                "key": "value",
-                "array": [1, 2, 3]
-            }
-        })
-    },
-    remove_nested_key = {
-        "-nested.key", Separator::Dot,
-        json!({
-            "existing_key": "value",
-            "array": [1, 2, 3],
-            "nested": {
-                "array": [1, 2, 3] 
-            }
-        })
-    },
-    remove_array_element = {
-        "-array[1]", Separator::Dot,
-        json!({
-            "existing_key": "value",
-            "array": [1, 3],
-            "nested": {
-                "key": "value",
-                "array": [1, 2, 3] 
-            }
-        })
-    },
-    remove_entire_array = {
-        "-array", Separator::Dot,
-        json!({
-            "existing_key": "value",
-            "nested": {
-                "key": "value",
-                "array": [1, 2, 3]
-            }
-        })
-    },
-    remove_nested_array_element = {
-        "-nested.array[0]", Separator::Dot,
-        json!({
-            "existing_key": "value",
-            "array": [1, 2, 3],
-            "nested": {
-                "key": "value",
-                "array": [2, 3]
-            }
-        })
-    },
-)]
-fn test_remove_operation_success(input: &str, separator: Separator, expected: serde_json::Value) {
-    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
-    assert_eq!(parsed.operation, Operation::Remove);
-
-    let mut json_obj = json!({
-        "existing_key": "value",
-        "array": [1, 2, 3],
-        "nested": {
-            "key": "value",
-            "array": [1, 2, 3]
-        }
-    });
-
-    parsed.apply_to(&mut json_obj).unwrap();
-
-    assert_eq!(json_obj, expected);
-}
-
-// Tests for the `Remove` operation that should **fail**.
-#[parameterized(
-    remove_nonexistent_key = {
-        "-nonexistent_key", Separator::Dot
-    },
-    remove_nonexistent_nested_key = {
-        "-nested.nonexistent_key", Separator::Dot
-    },
-    remove_nonexistent_array_element = {
-        "-array[10]", Separator::Dot
-    },
-    remove_from_nonexistent_array = {
-        "-nonexistent_array[0]", Separator::Dot
-    },
-
-)]
-fn test_remove_operation_failure(input: &str, separator: Separator) {
-    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
-    assert_eq!(parsed.operation, Operation::Remove);
-
-    let mut json_obj = json!({
-        "existing_key": "value",
-        "array": [1, 2, 3],
-        "nested": {
-            "key": "value",
-            "array": [1, 2, 3]
-        }
-    });
-
-    let result = parsed.apply_to(&mut json_obj);
-    assert!(result.is_err(), "Expected error but operation succeeded");
-}
-
-/// Tests for the `Auto` operation that should **succeed**.
-#[parameterized(
-    replace_existing_key = {
-        "existing_key=new_value", Separator::Dot,
-        json!({
-            "existing_key": "new_value",
-            "array": [1, 2, 3]
-        }),
-        Operation::Replace
-    },
-    add_new_key = {
-        "new_key=new_value", Separator::Dot,
-        json!({
-            "existing_key": "old_value",
-            "array": [1, 2, 3],
-            "new_key": "new_value"
-        }),
-        Operation::Add
-    },
-    insert_new_nested_key = {
-        "parent.new_child=new_value", Separator::Dot,
-        json!({
-            "existing_key": "old_value",
-            "array": [1, 2, 3],
-            "parent": {
-                "new_child": "new_value"
-            }
-        }),
-        Operation::Insert
-    },
-    replace_array_element = {
-        "array[1]=42", Separator::Dot,
-        json!({
-            "existing_key": "old_value",
-            "array": [1, 42, 3]
-        }),
-        Operation::Replace
-
-    },
-    add_to_array_end = {
-        "array[3]=4", Separator::Dot,
-        json!({
-            "existing_key": "old_value",
-            "array": [1, 2, 3, 4]
-        }),
-        Operation::Add
-    },
-    insert_new_array = {
-        "new_array[0]=1", Separator::Dot,
-        json!({
-            "existing_key": "old_value",
-            "array": [1, 2, 3],
-            "new_array": [1]
-        }),
-        Operation::Insert
-    },
-)]
-fn test_auto_operation(
-    input: &str,
-    separator: Separator,
-    expected: serde_json::Value,
-    epxected_operation: Operation,
+#[rstest]
+#[case("+parent.child.key=value", Separator::Dot, json!({"parent": {"child": {"key": "value"}}, "array": [1, 2, 3]}))]
+#[case("+array/1=42", Separator::Slash, json!({"parent": {"child": {}}, "array": [1, 42, 2, 3]}))]
+#[case("+array/-=99", Separator::Slash, json!({"parent": {"child": {}}, "array": [1, 2, 3, 99]}))]
+fn test_add_operation_success(
+    #[case] input: &str,
+    #[case] separator: Separator,
+    #[case] expected: serde_json::Value,
 ) {
     let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
-    assert_eq!(parsed.operation, Operation::Auto);
+    assert_eq!(parsed.operation(), &Operation::Add);
+
+    let mut json_obj = json!({
+        "parent": {
+            "child": {}
+        },
+        "array": [1, 2, 3]
+    });
+
+    parsed.apply_to(&mut json_obj).unwrap();
+
+    assert_eq!(json_obj, expected);
+}
+
+#[rstest]
+#[case("+nonexistent.key=value", Separator::Dot)]
+#[case("+nonexistent_array/0=value", Separator::Slash)]
+#[case("+array/10=value", Separator::Slash)]
+fn test_add_operation_failure(#[case] input: &str, #[case] separator: Separator) {
+    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
+    assert_eq!(parsed.operation(), &Operation::Add);
+
+    let mut json_obj = json!({
+        "parent": {
+            "child": {}
+        },
+        "array": [1, 2, 3]
+    });
+
+    let result = parsed.apply_to(&mut json_obj);
+    assert!(result.is_err(), "Expected error but operation succeeded");
+}
+
+#[rstest]
+#[case("=parent.child.key=new_value", Separator::Dot, json!({"parent": {"child": {"key": "new_value"}}, "array": [1, 2, 3], "root": "root_value"}))]
+#[case("=array/1=42", Separator::Slash, json!({"parent": {"child": {"key": "old_value"}}, "array": [1, 42, 3], "root": "root_value"}))]
+#[case("=root=new_root_value", Separator::Dot, json!({"parent": {"child": {"key": "old_value"}}, "array": [1, 2, 3], "root": "new_root_value"}))]
+#[case("=parent={\"new\": \"object\"}", Separator::Dot, json!({"parent": {"new": "object"}, "array": [1, 2, 3], "root": "root_value"}))]
+#[case("=parent.child.key=null", Separator::Dot, json!({"parent": {"child": {"key": null}}, "array": [1, 2, 3], "root": "root_value"}))]
+fn test_replace_operation_success(
+    #[case] input: &str,
+    #[case] separator: Separator,
+    #[case] expected: serde_json::Value,
+) {
+    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
+    assert_eq!(parsed.operation(), &Operation::Replace);
+
+    let mut json_obj = json!({
+        "parent": {
+            "child": {
+                "key": "old_value"
+            }
+        },
+        "array": [1, 2, 3],
+        "root": "root_value"
+    });
+
+    parsed.apply_to(&mut json_obj).unwrap();
+
+    assert_eq!(json_obj, expected);
+}
+
+#[rstest]
+#[case("=parent.child.nonexistent_key=new_value", Separator::Dot)]
+#[case("=array/10=42", Separator::Slash)]
+#[case("=nonexistent_root_key=value", Separator::Dot)]
+#[case("=array/1/key=value", Separator::Slash)]
+fn test_replace_operation_failure(#[case] input: &str, #[case] separator: Separator) {
+    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
+    assert_eq!(parsed.operation(), &Operation::Replace);
+
+    let mut json_obj = json!({
+        "parent": {
+            "child": {
+                "key": "old_value"
+            }
+        },
+        "array": [1, 2, 3],
+        "root": "root_value"
+    });
+
+    let result = parsed.apply_to(&mut json_obj);
+    assert!(result.is_err(), "Expected error but operation succeeded");
+}
+
+#[rstest]
+#[case("-existing_key", Separator::Dot, json!({"array": [1, 2, 3], "nested": {"key": "value", "array": [1, 2, 3]}}))]
+#[case("-nested.key", Separator::Dot, json!({"existing_key": "value", "array": [1, 2, 3], "nested": {"array": [1, 2, 3]}}))]
+#[case("-array[1]", Separator::Dot, json!({"existing_key": "value", "array": [1, 3], "nested": {"key": "value", "array": [1, 2, 3]}}))]
+#[case("-array", Separator::Dot, json!({"existing_key": "value", "nested": {"key": "value", "array": [1, 2, 3]}}))]
+#[case("-nested.array[0]", Separator::Dot, json!({"existing_key": "value", "array": [1, 2, 3], "nested": {"key": "value", "array": [2, 3]}}))]
+fn test_remove_operation_success(
+    #[case] input: &str,
+    #[case] separator: Separator,
+    #[case] expected: serde_json::Value,
+) {
+    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
+    assert_eq!(parsed.operation(), &Operation::Remove);
+
+    let mut json_obj = json!({
+        "existing_key": "value",
+        "array": [1, 2, 3],
+        "nested": {
+            "key": "value",
+            "array": [1, 2, 3]
+        }
+    });
+
+    parsed.apply_to(&mut json_obj).unwrap();
+
+    assert_eq!(json_obj, expected);
+}
+
+#[rstest]
+#[case("-nonexistent_key", Separator::Dot)]
+#[case("-nested.nonexistent_key", Separator::Dot)]
+#[case("-array[10]", Separator::Dot)]
+#[case("-nonexistent_array[0]", Separator::Dot)]
+fn test_remove_operation_failure(#[case] input: &str, #[case] separator: Separator) {
+    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
+    assert_eq!(parsed.operation(), &Operation::Remove);
+
+    let mut json_obj = json!({
+        "existing_key": "value",
+        "array": [1, 2, 3],
+        "nested": {
+            "key": "value",
+            "array": [1, 2, 3]
+        }
+    });
+
+    let result = parsed.apply_to(&mut json_obj);
+    assert!(result.is_err(), "Expected error but operation succeeded");
+}
+
+#[rstest]
+#[case("existing_key=new_value", Separator::Dot, json!({"existing_key": "new_value", "array": [1, 2, 3]}), Operation::Replace)]
+#[case("new_key=new_value", Separator::Dot, json!({"existing_key": "old_value", "array": [1, 2, 3], "new_key": "new_value"}), Operation::Add)]
+#[case("parent.new_child=new_value", Separator::Dot, json!({"existing_key": "old_value", "array": [1, 2, 3], "parent": {"new_child": "new_value"}}), Operation::Insert)]
+#[case("array[1]=42", Separator::Dot, json!({"existing_key": "old_value", "array": [1, 42, 3]}), Operation::Replace)]
+#[case("array[3]=4", Separator::Dot, json!({"existing_key": "old_value", "array": [1, 2, 3, 4]}), Operation::Add)]
+#[case("new_array[0]=1", Separator::Dot, json!({"existing_key": "old_value", "array": [1, 2, 3], "new_array": [1]}), Operation::Insert)]
+fn test_auto_operation(
+    #[case] input: &str,
+    #[case] separator: Separator,
+    #[case] expected: serde_json::Value,
+    #[case] expected_operation: Operation,
+) {
+    let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
+    assert_eq!(parsed.operation(), &Operation::Auto);
 
     let mut json_obj = json!({
         "existing_key": "old_value",
@@ -428,18 +221,16 @@ fn test_auto_operation(
     });
 
     let operation = parsed.apply_to(&mut json_obj).unwrap();
-    assert_eq!(operation, epxected_operation);
+    assert_eq!(operation, expected_operation);
 
     assert_eq!(json_obj, expected);
 }
 
-/// Tests for patch errors.
-#[parameterized(
-        remove_nonexistent_key = { "-nonexistent", Separator::Dot },
-        replace_nonexistent_key = { "=nonexistent=value", Separator::Dot },
-        add_invalid_index = { "+array[10]=value", Separator::Dot },
-    )]
-fn test_patch_errors(input: &str, separator: Separator) {
+#[rstest]
+#[case("-nonexistent", Separator::Dot)]
+#[case("=nonexistent=value", Separator::Dot)]
+#[case("+array[10]=value", Separator::Dot)]
+fn test_patch_errors(#[case] input: &str, #[case] separator: Separator) {
     let parsed = Jqesque::from_str_with_separator(input, separator).unwrap();
     let mut json_obj = json!({ "array": [1, 2, 3] });
     let result = parsed.apply_to(&mut json_obj);
@@ -454,27 +245,31 @@ fn test_patch_errors(input: &str, separator: Separator) {
     }
 }
 
-/// Tests for the `Test` operation that should **succeed**.
-#[parameterized(
-    test_existing_key = { "?key=value", Separator::Dot, json!({ "key": "value" }) },
-    test_nested_key = { "?parent.child=value", Separator::Dot, json!({ "parent": { "child": "value" } }) },
-    test_array_element = { "?array[0]=1", Separator::Dot, json!({ "array": [1, 2, 3] }) },
-    test_nested_array_element = { "?array[0][1]=2", Separator::Dot, json!({ "array": [[null, 2]] }) },
-)]
-fn test_test_operation_success(input: &str, separator: Separator, initial_json: serde_json::Value) {
+#[rstest]
+#[case("?key=value", Separator::Dot, json!({ "key": "value" }))]
+#[case("?parent.child=value", Separator::Dot, json!({ "parent": { "child": "value" } }))]
+#[case("?array[0]=1", Separator::Dot, json!({ "array": [1, 2, 3] }))]
+#[case("?array[0][1]=2", Separator::Dot, json!({ "array": [[null, 2]] }))]
+fn test_test_operation_success(
+    #[case] input: &str,
+    #[case] separator: Separator,
+    #[case] initial_json: serde_json::Value,
+) {
     let parsed = Jqesque::from_str_with_separator(input, separator).expect("Failed to parse input");
-    assert_eq!(parsed.operation, Operation::Test);
+    assert_eq!(parsed.operation(), &Operation::Test);
 
     let mut json_obj = initial_json;
     assert!(parsed.apply_to(&mut json_obj).is_ok());
 }
 
-/// Tests for test failed errors.
-#[parameterized(
-        test_value_mismatch = { "?key=expected_value", Separator::Dot, json!({ "key": "actual_value" }) },
-        test_nonexistent_key = { "?nonexistent=value", Separator::Dot, json!({ "key": "value" }) },
-    )]
-fn test_test_failed_errors(input: &str, separator: Separator, initial_json: serde_json::Value) {
+#[rstest]
+#[case("?key=expected_value", Separator::Dot, json!({ "key": "actual_value" }))]
+#[case("?nonexistent=value", Separator::Dot, json!({ "key": "value" }))]
+fn test_test_failed_errors(
+    #[case] input: &str,
+    #[case] separator: Separator,
+    #[case] initial_json: serde_json::Value,
+) {
     let parsed = Jqesque::from_str_with_separator(input, separator).unwrap();
     let mut json_obj = initial_json;
     let result = parsed.apply_to(&mut json_obj);
@@ -483,27 +278,18 @@ fn test_test_failed_errors(input: &str, separator: Separator, initial_json: serd
         "Expected TestFailedError but operation succeeded"
     );
     match result {
-        Err(JqesqueError::TestFailedError { expected, actual }) => {
-            println!(
-                "Test failed as expected. Expected: {}, Actual: {}",
-                expected, actual
-            );
-        }
-        Err(JqesqueError::InvalidPathError(_)) => {
-            // This can happen if the path doesn't exist
-        }
+        Err(JqesqueError::TestFailedError { .. }) => (),
+        Err(JqesqueError::InvalidPathError(_)) => (),
         Err(e) => panic!("Expected TestFailedError, got {:?}", e),
         _ => panic!("Expected error but operation succeeded"),
     }
 }
 
-/// Tests for invalid path errors.
-#[parameterized(
-        invalid_path_syntax = { "+key..subkey=value", Separator::Dot },
-        invalid_array_index = { "+array[-1]=value", Separator::Dot },
-        invalid_escape_sequence = { "+key\\subkey=value", Separator::Dot },
-    )]
-fn test_invalid_path_errors(input: &str, separator: Separator) {
+#[rstest]
+#[case("+key..subkey=value", Separator::Dot)]
+#[case("+array[-1]=value", Separator::Dot)]
+#[case("+key\\subkey=value", Separator::Dot)]
+fn test_invalid_path_errors(#[case] input: &str, #[case] separator: Separator) {
     let result = Jqesque::from_str_with_separator(input, separator);
     assert!(
         result.is_err(),
@@ -516,16 +302,80 @@ fn test_invalid_path_errors(input: &str, separator: Separator) {
     }
 }
 
-/// Tests for as_json method.
-#[parameterized(
-    simple_key = { ">key=value", json!({"key": "value"}) } ,
-    nested_keys = { ">parent.child=value", json!({"parent": {"child": "value"}}) },
-)]
-fn test_as_json(input: &str, expected: serde_json::Value) {
+#[rstest]
+#[case(">key=value", json!({"key": "value"}))]
+#[case(">parent.child=value", json!({"parent": {"child": "value"}}))]
+fn test_as_json(#[case] input: &str, #[case] expected: serde_json::Value) {
     let json_obj = input
         .parse::<Jqesque>()
         .expect("Failed to parse input")
         .as_json();
 
     assert_eq!(json_obj, expected);
+}
+
+#[test]
+fn test_strict_json_values_rejects_unquoted_text() {
+    let options = ParseOptions::new(Separator::Dot).strict_json_values(true);
+    let parsed = Jqesque::from_str_with_options("key=value", options);
+    assert!(matches!(parsed, Err(JqesqueError::NomError(_))));
+}
+
+#[test]
+fn test_strict_json_values_accepts_valid_json() {
+    let options = ParseOptions::new(Separator::Dot).strict_json_values(true);
+    let parsed = Jqesque::from_str_with_options("key=\"value\"", options).unwrap();
+
+    let mut json_obj = serde_json::Value::Null;
+    parsed.apply_to(&mut json_obj).unwrap();
+
+    assert_eq!(json_obj, json!({"key": "value"}));
+}
+
+#[test]
+fn test_max_path_depth_limit() {
+    let options = ParseOptions::new(Separator::Dot).max_path_depth(2);
+    let parsed = Jqesque::from_str_with_options("a.b.c=1", options);
+
+    assert!(matches!(
+        parsed,
+        Err(JqesqueError::LimitExceededError {
+            kind: "path depth",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn test_max_array_index_limit() {
+    let options = ParseOptions::new(Separator::Dot).max_array_index(10);
+    let parsed = Jqesque::from_str_with_options("a[11]=1", options);
+
+    assert!(matches!(
+        parsed,
+        Err(JqesqueError::LimitExceededError {
+            kind: "array index",
+            ..
+        })
+    ));
+}
+
+#[test]
+fn test_new_rejects_out_of_bounds_constructed_index() {
+    let parsed = Jqesque::new(
+        vec![
+            PathToken::Key("a".to_string()),
+            PathToken::Index(DEFAULT_MAX_ARRAY_INDEX + 1),
+        ],
+        Some(json!(1)),
+        Operation::Insert,
+    );
+
+    assert!(matches!(
+        parsed,
+        Err(JqesqueError::LimitExceededError {
+            kind: "array index",
+            ..
+        })
+    ));
 }


### PR DESCRIPTION
- add ParseOptions-driven parsing with strict JSON mode and configurable depth/index limits
- introduce explicit error variants for strict JSON failures and limit violations
- encapsulate Jqesque internals (constructors/getters) and validate limits on apply paths
- reduce insert clone churn by passing values by reference in manipulators
- migrate tests from yare to rstest and expand coverage for strict/limit behavior
- add CI workflow for fmt/clippy/tests/doc-tests plus cargo-deny and cargo-audit checks
- add cargo-fuzz setup with parse/apply and deep-path/index fuzz targets
- add iai-callgrind benchmarking with scenario fan-out (parse/insert/merge by size/depth)
- wire PR benchmark reporting via terjekv/github-action-iai-callgrind
- update README/CONTRIBUTING, add local check script, and ignore fuzz artifacts